### PR TITLE
feat(article): Add GitHub link for Awale project

### DIFF
--- a/articles/awale_1.html
+++ b/articles/awale_1.html
@@ -155,6 +155,7 @@ reward += 0.5 * captured  # Récompense pour la capture de graines
         <h2>Pour aller plus loin</h2>
         <p>Si vous souhaitez en savoir plus sur l'apprentissage par renforcement, l'Awalé ou JAX, voici quelques ressources utiles :</p>
         <ul>
+            <li><a href="https://github.com/5uru/awale">Repo GitHub de l'Awalé</a></li>
             <li><a href="https://spinningup.openai.com/en/latest/spinningup/rl_intro.html">Introduction à l'apprentissage par renforcement</a></li>
             <li><a href="https://en.wikipedia.org/wiki/Awale">Page Wikipédia sur l'Awalé</a></li>
             <li><a href="https://jax.readthedocs.io/en/latest/index.html">Documentation officielle de JAX</a></li>


### PR DESCRIPTION
Adds a new link to the "Pour aller plus loin" section of the "awale_1.html"
article, pointing to the GitHub repository for the Awale project. This
provides users with an additional resource to explore the Awale game
implementation in more detail.