### PR TITLE
feat(pages): Add research papers page and link in navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <nav>
         <a href="index.html">Accueil</a> |
         <a href="projects.html">Projets</a> |
+        <a href="papers.html">Papiers de Recherche</a> |
         <a href="about.html">À propos</a>
     </nav>
 </header>

--- a/papers.html
+++ b/papers.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Papiers de Recherche - Jonathan Suru</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header>
+  <h1>Jonathan Suru</h1>
+  <nav>
+    <a href="index.html">Accueil</a> |
+    <a href="projects.html">Projets</a> |
+    <a href="papers.html">Papiers de Recherche</a> |
+    <a href="about.html">À propos</a>
+  </nav>
+</header>
+
+<main>
+  <h2>Papiers de Recherche</h2>
+  <p>Cette section est dédiée à mes reproductions et implémentations de travaux académiques en IA.</p>
+
+
+</main>
+
+<footer>
+  <p><span class="copyleft">&copy;</span> 2024 Jonathan Suru. This work is free.</p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
The changes introduce a new `papers.html` page that displays information about the research papers I have implemented. This page is linked in the navigation menu on the `index.html` page. The goal is to provide a dedicated section for showcasing my academic work in the field of AI.