### PR TITLE
✨ feat(article): Add link to previous article on linear algebra

### DIFF
--- a/articles/dli25_vector_calculus.html
+++ b/articles/dli25_vector_calculus.html
@@ -20,7 +20,7 @@
 <h1>Calcul Vectoriel : Fondements Essentiels pour le Machine Learning</h1>
 
 
-<p>Cet article fait suite à notre précédent article "Algèbre Linéaire : Fondements Essentiels pour le Machine Learning". Si l'algèbre linéaire nous a fourni le langage pour décrire <em>où</em> vivent les vecteurs et les matrices, le calcul vectoriel nous explique <em>comment</em> les fonctions transforment ces espaces - comment les quantités changent lorsque nous nous déplaçons.</p>
+<p>Cet article fait suite à notre précédent article <a href="dli25_linear_algebra.html">"Algèbre Linéaire : Fondements Essentiels pour le Machine Learning"</a>. Si l'algèbre linéaire nous a fourni le langage pour décrire <em>où</em> vivent les vecteurs et les matrices, le calcul vectoriel nous explique <em>comment</em> les fonctions transforment ces espaces - comment les quantités changent lorsque nous nous déplaçons.</p>
 
 <p>Cet article s'inspire principalement d'une présentation issue du Deep Learning Indaba 2025 qui s'est tenu au Rwanda, organisée par Dr. Ismaila SECK, Géraud Nangue Tasse et l'équipe DLI. Comme indiqué dans leur présentation : "L'algèbre linéaire nous a donné le langage de là où vivent les vecteurs. Le calcul vectoriel nous dit comment les fonctions sculptent ces espaces - comment les quantités changent lorsque nous nous déplaçons."</p>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Converted the plain-text reference to the previous article into a clickable hyperlink within the Vector Calculus article.
  * The title “Algèbre Linéaire : Fondements Essentiels pour le Machine Learning” now links to dli25_linear_algebra.html.
  * No other text or behavior on the page was altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->